### PR TITLE
To support this library with jQuery 1.8 and newer replaced "load" to "on("load"...) 

### DIFF
--- a/slideshow/js/supersized.3.2.7.js
+++ b/slideshow/js/supersized.3.2.7.js
@@ -152,7 +152,7 @@
 					var slidePrev = base.el+' li:eq('+loadPrev+')';
 					imgPrev.appendTo(slidePrev).wrap('<a ' + imageLink + linkTarget + '></a>').parent().parent().addClass('image-loading prevslide');
 				
-					imgPrev.load(function(){
+					imgPrev.on('load', function(){
 						$(this).data('origWidth', $(this).width()).data('origHeight', $(this).height());
 						base.resizeNow();	// Resize background image
 					});	// End Load
@@ -169,7 +169,7 @@
 			var slideCurrent= base.el+' li:eq('+vars.current_slide+')';
 			img.appendTo(slideCurrent).wrap('<a ' + imageLink + linkTarget + '></a>').parent().parent().addClass('image-loading activeslide');
 			
-			img.load(function(){
+			img.on('load', function(){
 				base._origDim($(this));
 				base.resizeNow();	// Resize background image
 				base.launch();
@@ -185,7 +185,7 @@
 				var slideNext = base.el+' li:eq('+loadNext+')';
 				imgNext.appendTo(slideNext).wrap('<a ' + imageLink + linkTarget + '></a>').parent().parent().addClass('image-loading');
 				
-				imgNext.load(function(){
+				imgNext.on('load',function(){
 					$(this).data('origWidth', $(this).width()).data('origHeight', $(this).height());
 					base.resizeNow();	// Resize background image
 				});	// End Load
@@ -497,7 +497,7 @@
 				
 				img.appendTo(targetList).wrap('<a ' + imageLink + linkTarget + '></a>').parent().parent().addClass('image-loading').css('visibility','hidden');
 				
-				img.load(function(){
+				img.on('load', function(){
 					base._origDim($(this));
 					base.resizeNow();
 				});	// End Load
@@ -601,7 +601,7 @@
 				
 				img.appendTo(targetList).wrap('<a ' + imageLink + linkTarget + '></a>').parent().parent().addClass('image-loading').css('visibility','hidden');
 				
-				img.load(function(){
+				img.on('load', function(){
 					base._origDim($(this));
 					base.resizeNow();
 				});	// End Load
@@ -782,7 +782,7 @@
 					
 					img.appendTo(targetList).wrap('<a ' + imageLink + linkTarget + '></a>').parent().parent().addClass('image-loading').css('visibility','hidden');
 					
-					img.load(function(){
+					img.on('load', function(){
 						base._origDim($(this));
 						base.resizeNow();
 					});	// End Load
@@ -805,7 +805,7 @@
 					
 					img.appendTo(targetList).wrap('<a ' + imageLink + linkTarget + '></a>').parent().parent().addClass('image-loading').css('visibility','hidden');
 					
-					img.load(function(){
+					img.on('load', function(){
 						base._origDim($(this));
 						base.resizeNow();
 					});	// End Load


### PR DESCRIPTION
To support this library with jQuery 1.8 and newer
replaced "load" to "on("load"...)

Why?
Because .load(), .unload() or .error() that all are deprecated since jQuery 1.8. 
Looked up for these aliases in code and replaced them with the .on() method instead. 

For example:
  From:
     img.load(function(){...});
  To:
     img.on('load', function(){ ...});

Checked with jQuery 3.5.1 and this library works well